### PR TITLE
Implement AWS SIGv4 query string sorting and POST body signing.

### DIFF
--- a/src/vmod_awsrest.c
+++ b/src/vmod_awsrest.c
@@ -385,7 +385,7 @@ void vmod_v4_generic(const struct vrt_ctx *ctx,
     char *payload = NULL;
     if (ctx->req) {
         /* must cache req body to allow hash and send to backend */
-        VRT_CacheReqBody(ctx, 1024);
+        VRT_CacheReqBody(ctx, 10*1024*1024);
         VRB_Iterate(ctx->req, vcb_processbody, &payload);
     }
     if (payload == NULL)

--- a/src/vmod_awsrest.vcc
+++ b/src/vmod_awsrest.vcc
@@ -1,4 +1,4 @@
 $Module awsrest 3 Varnish AWS RESP API module
-$Init init_function
+$Event init_function
 $Function VOID v4_generic(STRING,STRING,STRING,STRING,STRING,STRING,BOOL)
 $Function STRING lf()


### PR DESCRIPTION
こんにちは　たなかさん。
これは SIGv4 が POST と sorted query parameters とおします。
みて　ください。

Implements:
* canonical query parameter sorting by parameter name, then by value when params are equal
* canonical URI path component with percent-escaping as required by SIGv4
* updates vcc definition from `$Init` to `$Event` for varnish 4.1
* http POST body is cached and hashed for the signature

This is enough to allow varnish to proxy AWS ElasticSearch requests in the "es" domain, using SIGv4 user authorization.

Example:

```
backend default {
    .host = "esdomain-customerhash.us-west-2.es.amazonaws.com";
    .port = "80";
}

sub vcl_recv {
    set req.http.host = "esdomain-customerhash.us-west-2.es.amazonaws.com";
    awsrest.v4_generic(
        "es",
        "us-west-2",
        "<aws_access_key>",
        "<aws_secret_key>",
        "host;",
        "host:" + req.http.host + awsrest.lf(),
        false
    );
}
```

Thanks to:
* https://github.com/xcir
* https://github.com/vimeo/libvmod-boltsort
* https://github.com/fastly/libvmod-urlcode