### PR TITLE
Fixes for 4.1.x

### DIFF
--- a/src/vmod_awsrest.c
+++ b/src/vmod_awsrest.c
@@ -116,8 +116,8 @@ void vmod_v4_generic(const struct vrt_ctx *ctx,
 	
 	////////////////
 	//get data
-	char *method;
-	char *requrl;
+	const char *method;
+	const char *requrl;
 	struct http *hp;
 	struct gethdr_s gs;
 	

--- a/src/vmod_awsrest.vcc
+++ b/src/vmod_awsrest.vcc
@@ -1,4 +1,4 @@
 $Module awsrest 3 Varnish AWS RESP API module
-$Init init_function
+$Event init_function
 $Function VOID v4_generic(STRING,STRING,STRING,STRING,STRING,STRING,BOOL)
 $Function STRING lf()


### PR DESCRIPTION
Hello,

I needed to get this plugin working under 4.1.x on Ubuntu 16.04 (and gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4) and these were the (simple) changes necessary to get it compiled and working.