### PR TITLE
Add temporary credential support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Prototype
                     STRING region,                // [ap-northeast-1]
                     STRING access_key,            // [your access key]
                     STRING secret_key,            // [your secret key]
+                    STRING session_token,         // [your session token (optional)]
                     STRING signed_headers,        // [host;]                                   x-amz-content-sha256;x-amz-date is appended by default.
                     STRING canonical_headers,     // [host:s3-ap-northeast-1.amazonaws.com\n]
                     BOOL   feature                // [false]                                   reserved param(for varnish4)
@@ -70,6 +71,7 @@ Example(set to req.*)
                       "ap-northeast-1",
                       "[Your Access Key]",
                       "[Your Secret Key]",
+                      "",
                       "host;",
                       "host:" + req.http.host + awsrest.lf(),
                       false
@@ -98,6 +100,7 @@ Example(set to bereq.*)
                       "ap-northeast-1",
                       "[Your Access Key]",
                       "[Your Secret Key]",
+                      "",
                       "host;",
                       "host:" + bereq.http.host + awsrest.lf(),
                       false
@@ -108,6 +111,33 @@ Example(set to bereq.*)
                 //25 BereqHeader    b x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
                 //25 BereqHeader    b x-amz-date: 20150704T103159Z
 
+Example(using session token)
+        ::
+
+                import awsrest;
+                
+                backend default {
+                  .host = "s3-ap-northeast-1.amazonaws.com";
+                }
+                
+                sub vcl_backend_fetch{
+                  set bereq.http.host = "s3-ap-northeast-1.amazonaws.com";
+                  awsrest.v4_generic(
+                      "s3",
+                      "ap-northeast-1",
+                      "[Your Access Key]",
+                      "[Your Secret Key]",
+                      "[Your Session Token]",
+                      "host;",
+                      "host:" + bereq.http.host + awsrest.lf(),
+                      false
+                  );
+                }
+                //data
+                //25 BereqHeader    b Authorization: AWS4-HMAC-SHA256 Credential=****************/20150704/ap-northeast-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=****************
+                //25 BereqHeader    b x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+                //25 BereqHeader    b x-amz-date: 20150704T103159Z
+                //25 BereqHeader    b x-amz-security-token: [Your Session Token]
 
 
 lf
@@ -189,6 +219,7 @@ COMMON PROBLEMS
        "ap-northeast-1",
        "[Your Access Key]",
        "[Your Secret Key]",
+       "",
        "host;",
        "host:" + req.http.host + awsrest.lf(),
        false
@@ -204,6 +235,7 @@ COMMON PROBLEMS
        "ap-northeast-1",
        "[Your Access Key]",
        "[Your Secret Key]",
+       "",
        "host;",
        "host:" + bereq.http.host + awsrest.lf(),
        false

--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -16,6 +16,7 @@ varnish v1 -vcl+backend {
 			"ap-northeast-1",
 			"[Your Access Key]",
 			"[Your Secret Key]",
+      "",
 			"host;",
 			"host:" + req.http.host + awsrest.lf(),
 			false
@@ -23,6 +24,9 @@ varnish v1 -vcl+backend {
 		if(req.http.Authorization){
 			set req.http.x-req = "1";
 		}
+    if(!req.http.x-amz-security-token){
+      set req.http.x-req-security-token = "1";
+    }
 	}
 	sub vcl_backend_fetch{
 		unset bereq.http.Authorization;
@@ -31,6 +35,7 @@ varnish v1 -vcl+backend {
 			"ap-northeast-1",
 			"[Your Access Key]",
 			"[Your Secret Key]",
+      "",
 			"host;",
 			"host:" + bereq.http.host + awsrest.lf(),
 			false
@@ -38,7 +43,9 @@ varnish v1 -vcl+backend {
 		if(bereq.http.Authorization){
 			set bereq.http.x-bereq = "1";
 		}
-
+    if(!bereq.http.x-amz-security-token){
+      set bereq.http.x-bereq-security-token = "1";
+    }
 	}
 } -start
 

--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -16,7 +16,7 @@ varnish v1 -vcl+backend {
 			"ap-northeast-1",
 			"[Your Access Key]",
 			"[Your Secret Key]",
-      "",
+			"",
 			"host;",
 			"host:" + req.http.host + awsrest.lf(),
 			false
@@ -24,9 +24,9 @@ varnish v1 -vcl+backend {
 		if(req.http.Authorization){
 			set req.http.x-req = "1";
 		}
-    if(!req.http.x-amz-security-token){
-      set req.http.x-req-security-token = "1";
-    }
+		if(!req.http.x-amz-security-token){
+			set req.http.x-req-security-token = "1";
+		}
 	}
 	sub vcl_backend_fetch{
 		unset bereq.http.Authorization;
@@ -35,7 +35,7 @@ varnish v1 -vcl+backend {
 			"ap-northeast-1",
 			"[Your Access Key]",
 			"[Your Secret Key]",
-      "",
+			"",
 			"host;",
 			"host:" + bereq.http.host + awsrest.lf(),
 			false
@@ -43,9 +43,9 @@ varnish v1 -vcl+backend {
 		if(bereq.http.Authorization){
 			set bereq.http.x-bereq = "1";
 		}
-    if(!bereq.http.x-amz-security-token){
-      set bereq.http.x-bereq-security-token = "1";
-    }
+		if(!bereq.http.x-amz-security-token){
+			set bereq.http.x-bereq-security-token = "1";
+		}
 	}
 } -start
 

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,0 +1,57 @@
+varnishtest "awsrest"
+
+server s1 {
+	rxreq
+	expect req.http.x-req-security-token == "req-token"
+	expect req.http.x-bereq-security-token == "bereq-token"
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import awsrest from "${vmod_topbuild}/src/.libs/libvmod_awsrest.so";
+
+	sub vcl_recv {
+		awsrest.v4_generic(
+			"s3",
+			"ap-northeast-1",
+			"[Your Access Key]",
+			"[Your Secret Key]",
+      "req-token",
+			"host;",
+			"host:" + req.http.host + awsrest.lf(),
+			false
+		);
+		if(req.http.Authorization){
+			set req.http.x-req = "1";
+		}
+    if(req.http.x-amz-security-token){
+      set req.http.x-req-security-token = req.http.x-amz-security-token;
+    }
+	}
+	sub vcl_backend_fetch{
+		unset bereq.http.Authorization;
+		awsrest.v4_generic(
+			"s3",
+			"ap-northeast-1",
+			"[Your Access Key]",
+			"[Your Secret Key]",
+      "bereq-token",
+			"host;",
+			"host:" + bereq.http.host + awsrest.lf(),
+			false
+		);
+		if(bereq.http.Authorization){
+			set bereq.http.x-bereq = "1";
+		}
+    if(bereq.http.x-amz-security-token){
+      set bereq.http.x-bereq-security-token = bereq.http.x-amz-security-token;
+    }
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+}
+
+client c1 -run

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -16,7 +16,7 @@ varnish v1 -vcl+backend {
 			"ap-northeast-1",
 			"[Your Access Key]",
 			"[Your Secret Key]",
-      "req-token",
+			"req-token",
 			"host;",
 			"host:" + req.http.host + awsrest.lf(),
 			false
@@ -24,9 +24,9 @@ varnish v1 -vcl+backend {
 		if(req.http.Authorization){
 			set req.http.x-req = "1";
 		}
-    if(req.http.x-amz-security-token){
-      set req.http.x-req-security-token = req.http.x-amz-security-token;
-    }
+		if(req.http.x-amz-security-token){
+			set req.http.x-req-security-token = req.http.x-amz-security-token;
+		}
 	}
 	sub vcl_backend_fetch{
 		unset bereq.http.Authorization;
@@ -35,7 +35,7 @@ varnish v1 -vcl+backend {
 			"ap-northeast-1",
 			"[Your Access Key]",
 			"[Your Secret Key]",
-      "bereq-token",
+			"bereq-token",
 			"host;",
 			"host:" + bereq.http.host + awsrest.lf(),
 			false
@@ -43,9 +43,9 @@ varnish v1 -vcl+backend {
 		if(bereq.http.Authorization){
 			set bereq.http.x-bereq = "1";
 		}
-    if(bereq.http.x-amz-security-token){
-      set bereq.http.x-bereq-security-token = bereq.http.x-amz-security-token;
-    }
+		if(bereq.http.x-amz-security-token){
+			set bereq.http.x-bereq-security-token = bereq.http.x-amz-security-token;
+		}
 	}
 } -start
 

--- a/src/vmod_awsrest.c
+++ b/src/vmod_awsrest.c
@@ -110,12 +110,11 @@ void vmod_v4_generic(VRT_CTX,
 	VCL_STRING region,                //= 'ap-northeast-1';
 	VCL_STRING access_key,            //= 'your access key';
 	VCL_STRING secret_key,            //= 'your secret key';
+  VCL_STRING token,                 //= 'optional session token';
 	VCL_STRING _signed_headers,       //= 'host;';// x-amz-content-sha256;x-amz-date is appended by default.
 	VCL_STRING _canonical_headers,    //= 'host:s3-ap-northeast-1.amazonaws.com\n'
 	VCL_BOOL feature                  //= reserved param(for varnish4)
 ){
-
-	
 	////////////////
 	//get data
 	const char *method;
@@ -166,15 +165,23 @@ void vmod_v4_generic(VRT_CTX,
 	////////////////
 	//create signed headers
 	size_t len = strlen(_signed_headers) + 32;
-	char *psigned_headers = WS_Alloc(ctx->ws,len);
-	sprintf(psigned_headers,"%sx-amz-content-sha256;x-amz-date",_signed_headers);
-	
+  size_t tokenlen = 0;
+  // Account for the addition of ";x-amz-security-token"
+  if(token != NULL) tokenlen = 21;
+	char *psigned_headers = WS_Alloc(ctx->ws,len+tokenlen);
+  char *psigned_headers_token = WS_Alloc(ctx->ws,tokenlen);
+  if(token != NULL) sprintf(psigned_headers_token,";x-amz-security-token");
+	sprintf(psigned_headers,"%sx-amz-content-sha256;x-amz-date%s",_signed_headers,psigned_headers_token);
 	
 	////////////////
 	//create canonical headers
 	len = strlen(_canonical_headers) + 115;
-	char *pcanonical_headers = WS_Alloc(ctx->ws,len);
-	sprintf(pcanonical_headers,"%sx-amz-content-sha256:%s\nx-amz-date:%s\n",_canonical_headers,payload_hash,amzdate);
+  // Account for addition of "x-amz-security-token:[token]\n"
+  if(token != NULL) tokenlen = 22 + strlen(token);
+  char *pcanonical_token_header = WS_Alloc(ctx->ws,tokenlen);
+	char *pcanonical_headers = WS_Alloc(ctx->ws,len+tokenlen);
+  if(token != NULL) sprintf(pcanonical_token_header,"x-amz-security-token:%s\n",token);
+	sprintf(pcanonical_headers,"%sx-amz-content-sha256:%s\nx-amz-date:%s\n%s",_canonical_headers,payload_hash,amzdate,pcanonical_token_header);
 	
 	////////////////
 	//create credential scope
@@ -241,6 +248,10 @@ void vmod_v4_generic(VRT_CTX,
 	VRT_SetHdr(ctx, &gs , payload_hash , vrt_magic_string_end);
 	gs.what = "\013x-amz-date:";
 	VRT_SetHdr(ctx, &gs           , amzdate , vrt_magic_string_end);
+  if(token != NULL){
+    gs.what="\025x-amz-security-token:";
+    VRT_SetHdr(ctx, &gs, token, vrt_magic_string_end);
+  }
 }
 
 VCL_STRING

--- a/src/vmod_awsrest.c
+++ b/src/vmod_awsrest.c
@@ -110,7 +110,7 @@ void vmod_v4_generic(VRT_CTX,
 	VCL_STRING region,                //= 'ap-northeast-1';
 	VCL_STRING access_key,            //= 'your access key';
 	VCL_STRING secret_key,            //= 'your secret key';
-  VCL_STRING token,                 //= 'optional session token';
+	VCL_STRING token,                 //= 'optional session token';
 	VCL_STRING _signed_headers,       //= 'host;';// x-amz-content-sha256;x-amz-date is appended by default.
 	VCL_STRING _canonical_headers,    //= 'host:s3-ap-northeast-1.amazonaws.com\n'
 	VCL_BOOL feature                  //= reserved param(for varnish4)
@@ -164,24 +164,24 @@ void vmod_v4_generic(VRT_CTX,
 	
 	////////////////
 	//create signed headers
-  size_t tokenlen = 0;
-  if(token != NULL) tokenlen = strlen(token);
+	size_t tokenlen = 0;
+	if(token != NULL) tokenlen = strlen(token);
 
 	size_t len = strlen(_signed_headers) + 32;
-  if(tokenlen > 0) len += 21; // ;x-amz-security-token
+	if(tokenlen > 0) len += 21; // ;x-amz-security-token
 	char *psigned_headers = WS_Alloc(ctx->ws,len);
-  char *psigned_headers_token = WS_Alloc(ctx->ws,21+tokenlen);
-  if(tokenlen > 0) sprintf(psigned_headers_token,";x-amz-security-token");
+	char *psigned_headers_token = WS_Alloc(ctx->ws,21+tokenlen);
+	if(tokenlen > 0) sprintf(psigned_headers_token,";x-amz-security-token");
 	sprintf(psigned_headers,"%sx-amz-content-sha256;x-amz-date%s",_signed_headers,psigned_headers_token);
 	
 	////////////////
 	//create canonical headers
 	len = strlen(_canonical_headers) + 115;
-  // Account for addition of "x-amz-security-token:[token]\n"
-  if(tokenlen > 0) len += 22;
-  char *pcanonical_token_header = WS_Alloc(ctx->ws,22+tokenlen);
+	// Account for addition of "x-amz-security-token:[token]\n"
+	if(tokenlen > 0) len += 22;
+	char *pcanonical_token_header = WS_Alloc(ctx->ws,22+tokenlen);
 	char *pcanonical_headers = WS_Alloc(ctx->ws,len+tokenlen);
-  if(token > 0) sprintf(pcanonical_token_header,"x-amz-security-token:%s\n",token);
+	if(token > 0) sprintf(pcanonical_token_header,"x-amz-security-token:%s\n",token);
 	sprintf(pcanonical_headers,"%sx-amz-content-sha256:%s\nx-amz-date:%s\n%s",_canonical_headers,payload_hash,amzdate,pcanonical_token_header);
 	
 	////////////////
@@ -249,10 +249,10 @@ void vmod_v4_generic(VRT_CTX,
 	VRT_SetHdr(ctx, &gs , payload_hash , vrt_magic_string_end);
 	gs.what = "\013x-amz-date:";
 	VRT_SetHdr(ctx, &gs           , amzdate , vrt_magic_string_end);
-  if(tokenlen > 0){
-    gs.what="\025x-amz-security-token:";
-    VRT_SetHdr(ctx, &gs, token, vrt_magic_string_end);
-  }
+	if(tokenlen > 0){
+	  gs.what="\025x-amz-security-token:";
+	  VRT_SetHdr(ctx, &gs, token, vrt_magic_string_end);
+	}
 }
 
 VCL_STRING

--- a/src/vmod_awsrest.vcc
+++ b/src/vmod_awsrest.vcc
@@ -1,4 +1,4 @@
 $Module awsrest 3 Varnish AWS RESP API module
 $Event init_function
-$Function VOID v4_generic(STRING,STRING,STRING,STRING,STRING,STRING,BOOL)
+$Function VOID v4_generic(STRING,STRING,STRING,STRING,STRING,STRING,STRING,BOOL)
 $Function STRING lf()


### PR DESCRIPTION
This is an implementation of the first solution I proposed in #19: it adds an _optional_ `session_token` parameter to the `v4_generic` function allowing AWS temporary credentials to be used. See that issue for a more complete description of the problem this is solving. If you do not include that parameter, the module continues to behave exactly as it did before for "permanent" credentials.

When you use AWS' STS service to [request temporary credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html):

> The AWS STS API actions return temporary security credentials that consist of an access key and a session token. The access key consists of an access key ID and a secret key.

The `session_token` parameter that this PR adds corresponds to the "session token" in the above description. It is commonly transmitted to AWS services as the `x-amz-security-token` header (AWS seem to use "session token" and "security token" somewhat interchangeably). This header is required when using temporary security credentials to authenticate, and since it is an `x-amz-`prefixed header, it _must_ be included in the V4 signature calculation.

Fixes #19 

---

@xcir this PR may be premature, and your answer to #19 may be "no, I will not consider it", but I figured it was better to show some code :smile: I need it for my use in either case, so would have had to write it anyway.